### PR TITLE
fix(template): conditionally render file directive only when zone has content

### DIFF
--- a/templates/config.j2
+++ b/templates/config.j2
@@ -3,7 +3,9 @@
 {% else %}
 {% for zone in coredns_default_zones + coredns_extra_zones %}
 {{ zone.name }} {
+{% if zone.content is defined or zone.url is defined or zone.src is defined %}
     file {{ zone.path | default('/etc/coredns/zones') }}/{{ zone.name }}
+{% endif %}
 {% if zone.plugins | default(false) %}
 {% for plugin in zone.plugins %}
 {% if plugin.config | default(false) %}


### PR DESCRIPTION
## Summary

- The `file` directive in `config.j2` is now conditionally rendered only when a zone has `content`, `url`, or `src` defined
- Forward-only zones (e.g., consul forward zones with only `plugins`) now render correctly without an unnecessary `file` line in the Corefile

## Problem

Previously, the `file` directive was always rendered for every zone, even when the zone had no file-backed content. This caused incorrect Corefile output for forward-only zones like:

```
consul.istanbul.internal.oflu.com {
  file /etc/coredns/zones/consul.istanbul.internal.oflu.com <-- unwanted forward
  . 127.0.0.1:8600
  cache 30
  errors
  log
}
```


## Solution

Wrapped the `file` directive with a Jinja2 conditional that checks for `zone.content`, `zone.url`, or `zone.src` before rendering. Now forward-only zones produce the expected output:

```
consul.istanbul.internal.oflu.com {
  forward . 127.0.0.1:8600
  cache 30
  errors
  log
}
```

